### PR TITLE
Changed FileField exceptions in order they work as a correct Validati…

### DIFF
--- a/src/django_rest_form_fields/exceptions.py
+++ b/src/django_rest_form_fields/exceptions.py
@@ -8,10 +8,12 @@ from django.core.exceptions import ValidationError
 
 class FileSizeError(ValidationError):
     def __init__(self, allowed_size, file_size):  # type: (int, int) -> None
-        self.message = "File is too big, max %d bytes are allowed (it has %d bytes)." % (allowed_size, file_size)
+        error = "File is too big, max %d bytes are allowed (it has %d bytes)." % (allowed_size, file_size)
+        super(ValidationError, self).__init__(error, code=413)
 
 
 class FileTypeError(ValidationError):
     def __init__(self, extension, valid_extensions):  # type: (str, List[str]) -> None
-        self.message = "File has invalid type, only [%s] are allowed (it has '%s')." \
-                       % (', '.join(valid_extensions), extension)
+        error = "File has invalid type, only [%s] are allowed (it has '%s')."  \
+                % (', '.join(valid_extensions), extension)
+        super(ValidationError, self).__init__(error, code=422)


### PR DESCRIPTION
Fixed https://github.com/M1hacka/django-rest-form-fields/issues/7:
Changed FileField exceptions in order they work as a correct ValidationError
